### PR TITLE
Pass props down to container span element

### DIFF
--- a/src/KeyboardEventHandler.js
+++ b/src/KeyboardEventHandler.js
@@ -99,9 +99,13 @@ export default class KeyboardEventHandler extends React.Component {
 
   render() {
     const { children } = this.props;
+    const passProps = Object.assign({}, this.props)
+    for (const key of Object.keys(KeyboardEventHandler.propTypes)) {
+      delete passProps[key]
+    }
     return children ? (<span ref={ e => {
         this.childrenContainer = e;
-      }}>{children}</span>) : null;
+      }} {...passProps}>{children}</span>) : null;
   }
 }
 


### PR DESCRIPTION
Pass any unused props down to the created `span` element.  This allows for control of the rendering of that span with styled-components and the like.

An alternative I haven't implemented here would be to specify a `as={CustomElement}` type thing, but this should do for many.

This PR does not contain the built library, only the source change.